### PR TITLE
add support for requiring ordered data from multiple gridftp streams

### DIFF
--- a/source/module/dsi.c
+++ b/source/module/dsi.c
@@ -261,9 +261,18 @@ dsi_stat(globus_gfs_operation_t   Operation,
 	globus_gridftp_server_finished_stat(Operation, result, NULL, 0);
 }
 
+
+/* Can request ordered data in globus-gridftp-server 11.x, removing the need to force transfers to a single stream */
+#ifdef GLOBUS_GFS_DSI_DESCRIPTOR_REQUIRES_ORDERED_DATA
+#define HPSS_DESC GLOBUS_GFS_DSI_DESCRIPTOR_SENDER | \
+                  GLOBUS_GFS_DSI_DESCRIPTOR_REQUIRES_ORDERED_DATA
+#else
+#define HPSS_DESC GLOBUS_GFS_DSI_DESCRIPTOR_SENDER
+#endif
+
 globus_gfs_storage_iface_t hpss_local_dsi_iface =
 {
-	0,            /* Descriptor       */
+	HPSS_DESC,    /* Descriptor       */
 	dsi_init,     /* init_func        */
 	dsi_destroy,  /* destroy_func     */
 	NULL,         /* list_func        */


### PR DESCRIPTION
A new feature in globus-gridftp-server 11.x lets you set a descriptor flag indicating that your DSI requires ordered data.  This enables a mode where data is guaranteed to be returned in order even with multiple parallel streams.  This is done by delaying reads from streams that are getting 'ahead' of the transfer, with some internal buffering for smoothing.  This *will* result in error on incoming data that is far out of order or with holes due to multiple restart ranges, but the intention of this mode is to support a DSI that would not be able to handle those cases to begin with.